### PR TITLE
Prerender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .bundle/
+.idea

--- a/scripts/config/lib/nginx_config.rb
+++ b/scripts/config/lib/nginx_config.rb
@@ -56,6 +56,7 @@ class NginxConfig
     end
 
     json["error_page"] ||= nil
+    json["prerender"] ||= nil
     json["debug"] = ENV['STATIC_DEBUG']
 
     logging = json["logging"] || {}
@@ -70,7 +71,6 @@ class NginxConfig
     end
     nameservers << [DEFAULT[:resolver]] unless nameservers.empty?
     json["resolver"] = nameservers.join(" ")
-
     json.each do |key, value|
       self.class.send(:define_method, key) { value }
     end

--- a/scripts/config/make-config
+++ b/scripts/config/make-config
@@ -4,9 +4,15 @@ require 'fileutils'
 require 'erb'
 require_relative 'lib/nginx_config'
 
-TEMPLATE     = File.join(File.dirname(__FILE__), 'templates/nginx.conf.erb')
-USER_CONFIG  = 'static.json'
-NGINX_CONFIG = 'config/nginx.conf'
+TEMPLATE               = File.join(File.dirname(__FILE__), 'templates/nginx.conf.erb')
+TEMPLATE_PRERENDER     = File.join(File.dirname(__FILE__), 'templates/prerender.conf.erb')
+USER_CONFIG            = 'static.json'
+NGINX_CONFIG           = 'config/nginx.conf'
+PRERENDER_CONFIG       = 'config/prerender.conf'
 
-erb = ERB.new(File.read(TEMPLATE)).result(NginxConfig.new(USER_CONFIG).context)
+context = NginxConfig.new(USER_CONFIG).context
+erb = ERB.new(File.read(TEMPLATE)).result(context)
 File.write(NGINX_CONFIG, erb)
+
+erb = ERB.new(File.read(TEMPLATE_PRERENDER)).result(context)
+File.write(PRERENDER_CONFIG, erb)

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -50,17 +50,9 @@ http {
   <% if proxies.any? %>
     resolver <%= resolver %>;
   <% end %>
-
-  <%= 'include prerender.conf;' if prerender %>
-
     location / {
       mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
-
-    <%if prerender %>
-      set $fallback @prerender;
-    <%else%>
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
-    <%end>
     <% if clean_urls %>
       try_files $uri.html $uri $uri/ $fallback;
     <% else %>
@@ -83,20 +75,23 @@ http {
   <% routes.each do |route, path| %>
     location ~ ^<%= route %>$ {
       set $route <%= route %>;
-      mruby_set $path /app/bin/config/lib/ngx_mruby/routes_path.rb cache;
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
     <% if clean_urls %>
-      try_files $uri.html $uri $uri/ $path $fallback;
+      try_files $uri.html $uri $uri/ $fallback;
     <% else %>
-      try_files $uri $path $fallback;
+      try_files $uri $fallback;
     <% end %>
     }
   <% end %>
 
+  <% if prerender %>
+    include prerender.conf;
+  <% else %>
   # need this b/c setting $fallback to =404 will try #{root}=404 instead of returning a 404
   location @404 {
     return 404;
   }
+  <% end %>
 
   # fallback proxy named match
   <% proxies.each do |location, hash| %>

--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -51,9 +51,16 @@ http {
     resolver <%= resolver %>;
   <% end %>
 
+  <%= 'include prerender.conf;' if prerender %>
+
     location / {
       mruby_post_read_handler /app/bin/config/lib/ngx_mruby/headers.rb cache;
+
+    <%if prerender %>
+      set $fallback @prerender;
+    <%else%>
       mruby_set $fallback /app/bin/config/lib/ngx_mruby/routes_fallback.rb cache;
+    <%end>
     <% if clean_urls %>
       try_files $uri.html $uri $uri/ $fallback;
     <% else %>

--- a/scripts/config/templates/prerender.conf.erb
+++ b/scripts/config/templates/prerender.conf.erb
@@ -1,0 +1,35 @@
+location @prerender {
+  proxy_set_header X-Prerender-Token <%= prerender['token'] %>;
+  set $prerender 0;
+
+  if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|Google.*snippet|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
+    set $prerender 1;
+  }
+  if ($args ~ "_escaped_fragment_") {
+    set $prerender 1;
+  }
+  if ($http_user_agent ~ "Prerender") {
+    set $prerender 0;
+  }
+  if ($uri ~* "\.(js|css|json|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)") {
+    set $prerender 0;
+  }
+
+  #resolve using Google's DNS server to force DNS resolution and prevent caching of IPs
+  resolver 8.8.8.8;
+
+  if ($prerender = 1) {
+    #setting prerender as a variable forces DNS resolution since nginx caches IPs
+    #and doesnt play well with load balancing
+    set $prerender <%= prerender['server_name'] %>;
+    <% if https_only %>
+      rewrite .* /https://$host$request_uri? break;
+    <% else %>
+      rewrite .* /$scheme://$host$request_uri? break;
+    <% end %>
+    proxy_pass https://$prerender;
+  }
+  if ($prerender = 0) {
+    rewrite .* /index.html break;
+  }
+}

--- a/scripts/config/templates/prerender.conf.erb
+++ b/scripts/config/templates/prerender.conf.erb
@@ -1,4 +1,4 @@
-location @prerender {
+location @404 {
   proxy_set_header X-Prerender-Token <%= prerender['token'] %>;
   set $prerender 0;
 

--- a/scripts/config/templates/prerender.conf.erb
+++ b/scripts/config/templates/prerender.conf.erb
@@ -1,5 +1,5 @@
 location @404 {
-  proxy_set_header X-Prerender-Token <%= prerender['token'] %>;
+  proxy_set_header X-Prerender-Token <%= ENV['PRERENDER_TOKEN'] || prerender['token'] %>;
   set $prerender 0;
 
   if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|Google.*snippet|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator") {
@@ -21,7 +21,7 @@ location @404 {
   if ($prerender = 1) {
     #setting prerender as a variable forces DNS resolution since nginx caches IPs
     #and doesnt play well with load balancing
-    set $prerender <%= prerender['server_name'] %>;
+    set $prerender <%= ENV['PRERENDER_HOST'] || prerender['server_name'] %>;
     <% if https_only %>
       rewrite .* /https://$host$request_uri? break;
     <% else %>


### PR DESCRIPTION
Reuses code from @mrbatista for current head of `heroku/heroku-buildpack-static`.

As we are using `heroku/heroku-buildpack-emberjs` our `static.json` gets modified to include catch-all redirect:
```json
{
  "routes": {
    "/**": "index.html"
  }
}
```
so this PR disables redirects instead makes `prerender.conf` handle urls that are not static assets and not `/api` urls. It's basically redirects that routes to `prerender.io` if user is bot otherwise it sends out `index.html` 